### PR TITLE
Fix skip back button

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -6,7 +6,7 @@
     var buttons = {
         "play-pause"   : ".play_pause_button",
         "jump-forward" : ".skip_forward_button",
-        "jump-back"    : ".skip_back_button"
+        "jump-back"    : ".skip-back-button"
     }
 
     chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {


### PR DESCRIPTION
It looks like they have changed some of the classes on the control buttons. The only one that is broken is the skip back button, but others could change in the future. This PR just updates the jump-back button to map to the `skip-back-button` class.

### Current Button Classes
##### Play pause:
```
animated-play-button play_pause_button pause_button
```

##### Skip forward:
```
styled__SkipButtonContainer-sc-15yu4aa-0 jQnA-Dt skip-forward-button skip_forward_button
```

##### Skip back:
```
styled__SkipBackButtonContainer-lkjo3k-0 bmmljd skip-back-button
```